### PR TITLE
Exclude Firefox profile directories from backup to reduce backup size

### DIFF
--- a/xfinity-usage/config.yaml
+++ b/xfinity-usage/config.yaml
@@ -17,6 +17,8 @@ panel_icon: mdi:network
 init: false
 map:
   - addon_config:rw
+backup_exclude:
+  - "profile*"
 services:
   - mqtt:want
 


### PR DESCRIPTION
On my instance the profile directories are 72.7 MB uncompressed or 23.2 MB compressed in the backup file. There is no need to back these up. Exclude them to reduce backup size.