### PR TITLE
Fix mqtt auto discovery null value for realz.

### DIFF
--- a/xfinity-usage/xfinity_usage_addon.py
+++ b/xfinity-usage/xfinity_usage_addon.py
@@ -541,7 +541,7 @@ class XfinityUsage ():
             # MQTT Home Assistant Device Config
             mqtt_client.mqtt_device_config_dict['device']['identifiers'] = mqtt_client.mqtt_device_details_dict.get('mac', [json_dict['attributes']['devices'][0]['id']])
             mqtt_client.mqtt_device_config_dict['device']['model'] = mqtt_client.mqtt_device_details_dict.get('model', json_dict['attributes']['devices'][0]['policyName'])
-            mqtt_client.mqtt_device_config_dict['device']['manufacturer'] = mqtt_client.mqtt_device_details_dict.get('make', 'unknown')
+            mqtt_client.mqtt_device_config_dict['device']['manufacturer'] = mqtt_client.mqtt_device_details_dict.get('make', None) or 'unknown'
             mqtt_client.mqtt_device_config_dict['device']['name'] = "Xfinity"
             """
             if bool(mqtt_client.mqtt_device_details_dict):


### PR DESCRIPTION
Regarding #22. This option is safer since it covers both a missing key and a None value.