### PR TITLE
fix: AttributeError: 'coroutine' object has no attribute 'encode' 

### DIFF
--- a/xfinity-usage/xfinity_usage_addon.py
+++ b/xfinity-usage/xfinity_usage_addon.py
@@ -618,7 +618,7 @@ class XfinityUsage ():
 
             datetime_format = datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f")
             page_content = await self.page.content()
-            page_content_hash = hash(base64.b64encode(await self.page.content().encode()).decode())
+            page_content_hash = hash(base64.b64encode(page_content.encode()).decode())
             page_screenshot = await self.page.screenshot()
             page_screenshot_hash = hash(base64.b64encode(page_screenshot).decode())
             


### PR DESCRIPTION
Fixes AttributeError: 'coroutine' object has no attribute 'encode' issue when enabling screenshot debug

Note: haven't been really to test as docker doesn't seem to include anything to edit file within the add-on.