### PR TITLE
fix: include code extraction instructions in addon log message

### DIFF
--- a/xfinity_usage/xfinity_token.py
+++ b/xfinity_usage/xfinity_token.py
@@ -122,6 +122,18 @@ f"""
 Using a browser, manually go to this url and login:
 {AUTH_URL}
 
+After login, you will be redirected. To find the code:
+  1. Open browser DevTools (Right-click > Inspect) BEFORE navigating
+  2. Go to the Network tab and check "Preserve log"
+  3. After login, filter requests by typing: code?
+  4. Click the xerxessecure.com request (status 302/307)
+  5. Look at the Response Headers > Location header
+  6. Copy the code value from the Location header (format: oi-<32hex>)
+
+NOTE: Do NOT copy the code from the browser URL bar (format: 0.ac.xxx).
+      That is an intermediate code. You need the oi- code from the
+      Location header of the 302/307 response.
+
 ************************************************************************************
 """)
 


### PR DESCRIPTION
## Summary

The addon's log message that prints the OAuth URL now includes step-by-step instructions for extracting the code from the `Location` header using browser DevTools.

## Problem

Users (including myself) were confused by the existing instructions and copied the intermediate code from the browser URL bar (`0.ac.e1.xxx`) instead of the `oi-<32hex>` code from the 302/307 response `Location` header. The addon rejects the intermediate code, making re-authentication impossible.

This is a known issue: #168

## Changes

Updated the log message in `xfinity_token.py` (the `logger.error` block that prints the auth URL) to include:
- Instructions to open DevTools and enable "Preserve log" before navigating
- Steps to filter by `code?`, find the 302/307 response, and read the `Location` header
- Explicit warning not to copy the `0.ac.` code from the URL bar

No code logic changes — only the log message text.

## Testing

- All 13 existing tests pass
- Verified the fix on a live HA instance: the improved log message guided successful code extraction and re-authentication

## Related

Fixes #168